### PR TITLE
Empty values

### DIFF
--- a/lib/mongoid-filterable/filterable.rb
+++ b/lib/mongoid-filterable/filterable.rb
@@ -14,7 +14,8 @@ module Mongoid
         criteria = unscoped
 
         filtering_params.each do |key, value|
-          if !value.nil? && respond_to?("filter_with_#{key}")
+          # false is permitted in order to work properly with boolean fields
+          if (value.present? || value == false) && respond_to?("filter_with_#{key}")
             if value.is_a?(Array) && scopes["filter_with_#{key}".to_sym][:scope].arity > 1
               selectors.push criteria.public_send("filter_with_#{key}", *value).selector
             else

--- a/spec/filterable_spec.rb
+++ b/spec/filterable_spec.rb
@@ -124,6 +124,22 @@ describe Mongoid::Filterable do
     end
   end
 
+  context 'when value is nil' do
+    it 'should ignore filter' do
+      City.create(people: 100)
+      City.create(people: 500)
+      expect(City.filter(people: nil).count).to eq(2)
+    end
+  end
+
+  context 'when value is empty string' do
+    it 'should ignore filter' do
+      City.create(people: 100)
+      City.create(people: 500)
+      expect(City.filter(people: '').count).to eq(2)
+    end
+  end
+
   context 'when value is a Boolean' do
     it 'should filter using a query' do
       City.create(name: 'city1')


### PR DESCRIPTION
We want that empty string values are ignored when filter.
This behaviour was changed from 0.3.1 to 0.4.0 accidentally and
this commit fixes that.