### PR TITLE
Escaped special chars on normalized filter

### DIFF
--- a/lib/mongoid-filterable/filterable.rb
+++ b/lib/mongoid-filterable/filterable.rb
@@ -47,7 +47,7 @@ module Mongoid
       def filter_by_normalized(attr)
         normalized_name = (attr.to_s + '_normalized').to_sym
         scope "filter_with_#{attr}", lambda { |value|
-          where(normalized_name => Regexp.new(I18n.transliterate(value), 'i'))
+          where(normalized_name => Regexp.new(Regexp.escape(I18n.transliterate(value)), 'i'))
         }
       end
     end

--- a/spec/filterable_spec.rb
+++ b/spec/filterable_spec.rb
@@ -58,11 +58,18 @@ describe Mongoid::Filterable do
       expect(City.filtrate(people: 500).first.people).to eq(1000)
     end
 
-    it 'should filter by normalized filter' do
-      City.create(country_normalized: 'spain')
-      City.create(country_normalized: 'france')
-      expect(City.filtrate(country: 'spain').count).to eq(1)
-      expect(City.filtrate(country: 'spain').first.country_normalized).to eq('spain')
+    context 'when using a normalized filter' do
+      it 'should filter' do
+        City.create(country_normalized: 'spain')
+        City.create(country_normalized: 'france')
+        expect(City.filtrate(country: 'spain').count).to eq(1)
+        expect(City.filtrate(country: 'spain').first.country_normalized).to eq('spain')
+      end
+
+      it 'should admit special regexp chars' do
+        expect { City.filtrate(country: 'spain (') }.to_not raise_error
+        expect { City.filtrate(country: 'spain [') }.to_not raise_error
+      end
     end
 
     it 'should respect previous selector' do


### PR DESCRIPTION
Se lanzaba este error 500 al buscar por campo normalizado con paréntesis o corchetes abiertos, debido a que se le pasan a Regexp y no crea una expresión regular válida.

![image](https://user-images.githubusercontent.com/10598666/62107545-1f3f4200-b2a8-11e9-8dd0-42a8fd0ba141.png)
