### PR TITLE
Fixed method chaining on mongoid 7.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ sudo: false
 language: ruby
 rvm:
   - 2.6.0
-before_install: gem install bundler -v 1.16.1
+  - 2.7.2
+before_install: gem install bundler -v 2.2.14
 
 gemfile:
   - Gemfile
@@ -11,10 +12,3 @@ gemfile:
 
 services:
   - mongodb
-
-addons:
-  apt:
-    sources:
-      - mongodb-3.4-precise
-    packages:
-      - mongodb-org-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ before_install: gem install bundler -v 2.2.14
 gemfile:
   - Gemfile
   - gemfiles/mongoid-6.0.gemfile
-  - gemfiles/mongoid-7.0.gemfile
 
 services:
   - mongodb

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rake'
-gem 'mongoid', "~> 5.0"
+gem 'mongoid', "~> 7.0"

--- a/lib/mongoid-filterable/filterable.rb
+++ b/lib/mongoid-filterable/filterable.rb
@@ -12,7 +12,7 @@ module Mongoid
 
         results = all
         selectors = []
-        criteria = Mongoid::Criteria.new(self).unscoped
+        criteria = Mongoid::Criteria.new(results).unscoped
 
         filtering_params.each do |key, value|
           if respond_to?("filter_with_#{key}")

--- a/mongoid-filterable.gemspec
+++ b/mongoid-filterable.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.5'
+  spec.add_development_dependency 'bundler', '~> 2.2'
   spec.add_development_dependency 'rspec'
   spec.add_dependency 'i18n'
   spec.add_dependency 'mongoid', ['>= 3.0', '< 8.0']

--- a/spec/filterable_spec.rb
+++ b/spec/filterable_spec.rb
@@ -32,10 +32,10 @@ describe Mongoid::Filterable do
   context 'when use default operator' do
     it 'should create correct selector' do
       expect(City.filtrate(code: :code1).selector).to eq(
-        'active' => true, '$and' => [{'code' => :code1}]
+        'active' => true, '$and' => [{'active' => true, 'code' => :code1}]
       )
       expect(City.unscoped.where(active: true).filtrate(code: :code1).selector).to eq(
-        'active' => true, '$and' => [{'code' => :code1}]
+        'active' => true, '$and' => [{'active' => true, 'code' => :code1}]
       )
     end
 
@@ -165,6 +165,16 @@ describe Mongoid::Filterable do
       City.create(name: '1', people: 1000)
       City.create(name: '1', people: 1000)
       expect(City.where(name: '2').filtrate(nil).count).to eq(1)
+    end
+  end
+
+  context 'with method chaining' do
+    it 'applies all scopes' do
+      City.create(name: '2', people: 100)
+      City.create(name: '1', people: 500)
+      City.create(name: '3', people: 100)
+
+      expect(City.filtrate(name: '2').filtrate(people_range: [100, 500]).count).to eq(1)
     end
   end
 end


### PR DESCRIPTION
This commit fixes an issue when chaining filtrate calls on mongoid 7.x.